### PR TITLE
fix: use statusCode instead of statusText

### DIFF
--- a/html/video.html
+++ b/html/video.html
@@ -112,7 +112,7 @@
     var isOnAir = function() {
         var oReq = new XMLHttpRequest();
         oReq.addEventListener("load", function() {
-            if(this.statusText == "OK") {
+            if(this.status == 200) {
 		onAir = true;
                 overlayOff();
                 player.play();


### PR DESCRIPTION
diffrent webservers e.g. HAProxy as LoadBalancer use different statusTexts, so don't test for the text but use code